### PR TITLE
If a browser field makes browser-resolve ignore an import, replace with {}

### DIFF
--- a/js/babel-plugin-sprockets-commoner-internal/test/fixtures/browser-resolve/actual.js
+++ b/js/babel-plugin-sprockets-commoner-internal/test/fixtures/browser-resolve/actual.js
@@ -1,3 +1,5 @@
 import a from './shimmed';
+import './ignored';
+import b from './ignored';
 
 a();

--- a/js/babel-plugin-sprockets-commoner-internal/test/fixtures/browser-resolve/expected.js
+++ b/js/babel-plugin-sprockets-commoner-internal/test/fixtures/browser-resolve/expected.js
@@ -3,6 +3,10 @@ var __commoner_module__actual_js = __commoner_initialize_module__(function (modu
 
   var _shimmed2 = _interopRequireDefault(__commoner_module__shimmed_browser_js);
 
+  var _ignored = {};
+
+  var _ignored2 = _interopRequireDefault(_ignored);
+
   function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
   (0, _shimmed2.default)();

--- a/js/babel-plugin-sprockets-commoner-internal/test/fixtures/browser-resolve/package.json
+++ b/js/babel-plugin-sprockets-commoner-internal/test/fixtures/browser-resolve/package.json
@@ -1,5 +1,6 @@
 {
   "browser": {
-    "./shimmed.js": "./shimmed-browser.js"
+    "./shimmed.js": "./shimmed-browser.js",
+    "./ignored.js": false
   }
 }


### PR DESCRIPTION
@nneufeld 