### PR TITLE
Optimize away empty files

### DIFF
--- a/js/babel-plugin-sprockets-commoner-internal/index.js
+++ b/js/babel-plugin-sprockets-commoner-internal/index.js
@@ -269,9 +269,21 @@ module.exports = function (context) {
 
           // Transform module to a variable assignment.
           // This variable is then referenced by any dependant children.
-          node.body = [t.variableDeclaration('var', [t.variableDeclarator(t.identifier(identifier), t.callExpression(t.identifier('__commoner_initialize_module__'), [t.functionExpression(null, [t.identifier('module'), t.identifier('exports')], t.blockStatement(node.body, node.directives))]))])];
+          var block = t.blockStatement(node.body, node.directives);
+          var f = t.functionExpression(null, [t.identifier('module'), t.identifier('exports')], block);
+          var call = t.callExpression(t.identifier('__commoner_initialize_module__'), [f]);
+          var declarator = t.variableDeclarator(t.identifier(identifier), call);
+          var declaration = t.variableDeclaration('var', [declarator]);
+
+          node.body = [declaration];
           node.directives = [];
+
+          // Rewrite calls
           path.traverse(callRewriter, state);
+
+          if (block.body.length === 0) {
+            declarator.init = t.objectExpression([]);
+          }
         }
       }
     }

--- a/js/babel-plugin-sprockets-commoner-internal/test/fixtures/optimize-away/expected.js
+++ b/js/babel-plugin-sprockets-commoner-internal/test/fixtures/optimize-away/expected.js
@@ -1,1 +1,1 @@
-var __commoner_module__actual_js = __commoner_initialize_module__(function (module, exports) {});
+var __commoner_module__actual_js = {};

--- a/test/babelrc_exclude_test.rb
+++ b/test/babelrc_exclude_test.rb
@@ -25,7 +25,7 @@ var global = window;
 var __commoner_module__babelrc_exclude$excludeme_js = __commoner_initialize_module__(function (module, exports) {
   export const a = 1;
 });
-var __commoner_module__babelrc_exclude$index_js = __commoner_initialize_module__(function (module, exports) {});
+var __commoner_module__babelrc_exclude$index_js = {};
 }();
 JS
   end

--- a/test/fixtures/arrow/index.js
+++ b/test/fixtures/arrow/index.js
@@ -1,5 +1,6 @@
 import info from './extra';
 import './second';
+import './empty';
 
 const a = (x) => x * x;
 

--- a/test/rewire_test.rb
+++ b/test/rewire_test.rb
@@ -112,6 +112,7 @@ var __commoner_module__arrow$second_js = __commoner_initialize_module__(function
 
   console.log(_extra2.default);
 });
+var __commoner_module__arrow$empty_js = {};
 var __commoner_module__arrow$index_js = __commoner_initialize_module__(function (module, exports) {
   'use strict';
 

--- a/test/root_node_modules_test.rb
+++ b/test/root_node_modules_test.rb
@@ -21,7 +21,7 @@ var global = window;
 var __commoner_module__root_node_modules$node_modules$empty_module$index_js = __commoner_initialize_module__(function (module, exports) {
   module.exports = null;
 });
-var __commoner_module__root_node_modules$assets$script_js = __commoner_initialize_module__(function (module, exports) {});
+var __commoner_module__root_node_modules$assets$script_js = {};
 }();
 JS
   end

--- a/test/stub_test.rb
+++ b/test/stub_test.rb
@@ -30,7 +30,7 @@ var __commoner_module__vendor_stub$admin$whatever_js = __commoner_initialize_mod
     return console.log('1337');
   });
 });
-var __commoner_module__vendor_stub$index_js = __commoner_initialize_module__(function (module, exports) {});
+var __commoner_module__vendor_stub$index_js = {};
 }();
 JS
   end


### PR DESCRIPTION
This makes it so files that contain no statements/only contain `require` statements are optimized to not call `__commoner_initialize_module__`. This makes sure uglifyjs can just completely optimize away the module definition.