### PR TITLE
Don't use the babel version in the cache key

### DIFF
--- a/lib/sprockets/commoner/processor.rb
+++ b/lib/sprockets/commoner/processor.rb
@@ -59,7 +59,6 @@ module Sprockets
         @cache_key ||= [
           self.class.name,
           VERSION,
-          version,
           @include.map(&:to_s),
           @exclude.map(&:to_s),
           @babel_exclude.map(&:to_s),


### PR DESCRIPTION
This prevents a node.js process being started if we need the cache key, but don't actually transform anything. We don't really need the babel version in the cache key, unless there's been a major bump but then the user should just wipe the cache or something.

@sirupsen