### PR TITLE
Read the babel version from its package.json and include in cache_key

### DIFF
--- a/test/cache_key_test.rb
+++ b/test/cache_key_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class CacheKeyTest < MiniTest::Test
+  def setup
+    @dir = File.join(__dir__, 'fixtures')
+    @processor = Sprockets::Commoner::Processor.new(@dir)
+  end
+
+  def test_cache_key
+    assert_equal ['Sprockets::Commoner::Processor', '2', '6.9.1', [@dir], [File.join(@dir, 'vendor/bundle')], [/node_modules/.to_s]], @processor.cache_key
+  end
+
+  def test_babel_missing_cache_key
+    error = assert_raises Schmooze::DependencyError do
+      Dir.mktmpdir do |dir|
+        Sprockets::Commoner::Processor.new(dir).cache_key
+      end
+    end
+
+    assert_equal 'Cannot determine babel version as babel-core has not been installed', error.message
+  end
+end

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "babel-core": "latest",
-    "babel-preset-es2015": "latest"
+    "babel-core": "6.9.1",
+    "babel-preset-es2015": "6.9.0"
   }
 }


### PR DESCRIPTION
@sirupsen @rafaelfranca