### PR TITLE
Add Sprockets::Commoner::Processor.configure method

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,7 @@ By default, commoner will process any file under the application root directory.
 ```ruby
 # In config/initializers/sprockets_commoner.rb
 Rails.application.config.assets.configure do |env|
-  env.unregister_postprocessor('application/javascript', Sprockets::Commoner::Processor)
-  env.register_postprocessor('application/javascript', Sprockets::Commoner::Processor.new(
-    env.root,
+  Sprockets::Commoner::Processor.configure(env,
     # include, exclude, and babel_exclude patterns can be path prefixes or regexes.
     # Explicitely list paths to include. The default is `[env.root]`
     include: ['app/assets/javascripts/subdirectory'],
@@ -66,7 +64,7 @@ Rails.application.config.assets.configure do |env|
     # Anything listed in babel_exclude has its require calls resolved, but no transforms listed in .babelrcs applied.
     # Default is [/node_modules/]
     babel_exclude: [/node_modules/]
-  ))
+  )
 end
 ```
 

--- a/lib/sprockets/commoner/processor.rb
+++ b/lib/sprockets/commoner/processor.rb
@@ -47,6 +47,15 @@ module Sprockets
         instance(input[:environment]).call(input)
       end
 
+      def self.configure(env, *args, **kwargs)
+        env.postprocessors['application/javascript'].each do |processor|
+          if processor == self || processor.is_a?(self)
+            env.unregister_postprocessor('application/javascript', processor)
+          end
+        end
+        env.register_postprocessor('application/javascript', self.new(env.root, *args, **kwargs))
+      end
+
       attr_reader :include, :exclude, :babel_exclude
       def initialize(root, include: [root], exclude: ['vendor/bundle'], babel_exclude: [/node_modules/])
         @root = root

--- a/test/babelrc_exclude_test.rb
+++ b/test/babelrc_exclude_test.rb
@@ -3,11 +3,7 @@ require 'test_helper'
 class BabelRcExcludeTest < MiniTest::Test
   def setup
     @env = Sprockets::Environment.new(File.join(__dir__, 'fixtures'))
-    @env.unregister_postprocessor('application/javascript', Sprockets::Commoner::Processor)
-    @env.register_postprocessor('application/javascript', Sprockets::Commoner::Processor.new(
-      @env.root,
-      babel_exclude: [/excludeme/],
-    ))
+    Sprockets::Commoner::Processor.configure(@env, babel_exclude: [/excludeme/])
     @env.append_path File.join(__dir__, 'fixtures')
   end
 

--- a/test/configure_test.rb
+++ b/test/configure_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class ConfigureTest < MiniTest::Test
+  def test_configure_twice
+    env = Sprockets::Environment.new(File.join(__dir__, 'fixtures'))
+    env.append_path File.join(__dir__, 'fixtures')
+    # This tests configuring twice, to make sure the second call overwrites the first
+    Sprockets::Commoner::Processor.configure(env, exclude: ['no-rewire/index.js'])
+    Sprockets::Commoner::Processor.configure(env, exclude: [])
+
+    assert asset = env['no-rewire.js']
+    assert_equal <<-JS.chomp, asset.to_s.chomp
+!function() {
+var __commoner_initialize_module__ = function(f) {
+  var module = {exports: {}};
+  f.call(module.exports, module, module.exports);
+  return module.exports;
+};
+var global = window;
+
+var __commoner_module__no_rewire$index_js = __commoner_initialize_module__(function (module, exports) {
+  "use strict";
+
+  var a = 1;
+});
+}();
+JS
+  end
+end

--- a/test/no_babel_test.rb
+++ b/test/no_babel_test.rb
@@ -3,11 +3,7 @@ require 'test_helper'
 class NoBabelTest < MiniTest::Test
   def setup
     @env = Sprockets::Environment.new(File.join(__dir__, 'fixtures'))
-    @env.unregister_postprocessor('application/javascript', Sprockets::Commoner::Processor)
-    @env.register_postprocessor('application/javascript', Sprockets::Commoner::Processor.new(
-      @env.root,
-      exclude: ['nobabelrc/index.js'],
-    ))
+    Sprockets::Commoner::Processor.configure(@env, exclude: ['nobabelrc/index.js'])
     @env.append_path File.join(__dir__, 'fixtures')
   end
 

--- a/test/reject_excluded_test.rb
+++ b/test/reject_excluded_test.rb
@@ -3,11 +3,7 @@ require 'test_helper'
 class RejectExcludedTest < MiniTest::Test
   def setup
     @env = Sprockets::Environment.new(File.join(__dir__, 'fixtures'))
-    @env.unregister_postprocessor('application/javascript', Sprockets::Commoner::Processor)
-    @env.register_postprocessor('application/javascript', Sprockets::Commoner::Processor.new(
-      @env.root,
-      exclude: ['dont-reject-unused/excluded.js', 'reject-excluded-files/excluded.js'],
-    ))
+    Sprockets::Commoner::Processor.configure(@env, exclude: ['dont-reject-unused/excluded.js', 'reject-excluded-files/excluded.js'])
     @env.append_path File.join(__dir__, 'fixtures')
   end
 


### PR DESCRIPTION
This replaces the brittle unregistering and registering of the processor

@tanema @rafaelfranca

Fixes #29