### PR TITLE
Add extra_options parameter to Processor

### DIFF
--- a/js/babel-plugin-sprockets-commoner-internal/index.js
+++ b/js/babel-plugin-sprockets-commoner-internal/index.js
@@ -254,15 +254,6 @@ module.exports = function (context) {
             extensions: ['.js', '.json', '.coffee', '.js.erb', '.coffee.erb']
           };
 
-          // Look for the sprockets-commoner plugin for extra options
-          state.file.opts.plugins.map(function (plugin) {
-            return plugin[1];
-          }).filter(function (opts) {
-            return opts != null && opts.__commoner_options;
-          }).forEach(function (plugin) {
-            return Object.assign(opts, plugin);
-          });
-
           Object.assign(opts, state.opts, { basedir: dirname(state.file.opts.filename) });
           rootRegex = new RegExp('^' + state.file.opts.sourceRoot + '/');
           identifierRegex = createIdentifierRegex();

--- a/js/babel-plugin-sprockets-commoner-internal/test/.babelrc
+++ b/js/babel-plugin-sprockets-commoner-internal/test/.babelrc
@@ -1,3 +1,3 @@
 {
-  plugins: ["transform-es2015-modules-commonjs", "transform-es2015-arrow-functions", "../"]
+  plugins: ["transform-es2015-modules-commonjs", "transform-es2015-arrow-functions"]
 }

--- a/js/babel-plugin-sprockets-commoner/README.md
+++ b/js/babel-plugin-sprockets-commoner/README.md
@@ -1,3 +1,0 @@
-# commoner-options
-
-This is a dummy Babel plugin that's just used to receive options from Sprockets.

--- a/js/babel-plugin-sprockets-commoner/index.js
+++ b/js/babel-plugin-sprockets-commoner/index.js
@@ -1,7 +1,0 @@
-module.exports = function () {
-  return {
-    pre: function pre() {
-      this.opts.__commoner_options = true;
-    }
-  };
-};

--- a/js/babel-plugin-sprockets-commoner/package.json
+++ b/js/babel-plugin-sprockets-commoner/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "babel-plugin-commoner-options",
-  "description": "A bogus plugin used for receiving options from Sprockets",
-  "private": true
-}

--- a/test/cache_key_test.rb
+++ b/test/cache_key_test.rb
@@ -3,11 +3,22 @@ require 'test_helper'
 class CacheKeyTest < MiniTest::Test
   def setup
     @dir = File.join(__dir__, 'fixtures')
-    @processor = Sprockets::Commoner::Processor.new(@dir)
   end
 
-  def test_cache_key
-    assert_equal ['Sprockets::Commoner::Processor', '2', '6.9.1', [@dir], [File.join(@dir, 'vendor/bundle')], [/node_modules/.to_s]], @processor.cache_key
+  def test_default_cache_key
+    processor = Sprockets::Commoner::Processor.new(@dir)
+    assert_equal ['Sprockets::Commoner::Processor', '2', '6.9.1', [@dir], [File.join(@dir, 'vendor/bundle')], [/node_modules/.to_s], []], processor.cache_key
+  end
+
+  def test_opts_cache_key
+    processor = Sprockets::Commoner::Processor.new(@dir, transform_options: {
+      /index.js$/ => {
+        globals: {
+          'jquery' => '$'
+        }
+      }
+    })
+    assert_equal ['Sprockets::Commoner::Processor', '2', '6.9.1', [@dir], [File.join(@dir, 'vendor/bundle')], [/node_modules/.to_s], [[/index.js$/.to_s, {globals: {'jquery' => '$'}}]]], processor.cache_key
   end
 
   def test_babel_missing_cache_key

--- a/test/fixtures/extra-options/index.js
+++ b/test/fixtures/extra-options/index.js
@@ -1,0 +1,3 @@
+var $ = require('jquery');
+
+$.ajax('/whatever');

--- a/test/fixtures/vendor-stub/admin/.babelrc
+++ b/test/fixtures/vendor-stub/admin/.babelrc
@@ -1,10 +1,3 @@
 {
-  "presets": ["es2015"],
-  "plugins": [
-    ["sprockets-commoner", {
-      "globals": {
-        "jquery": "$"
-      }
-    }]
-  ]
+  "presets": ["es2015"]
 }

--- a/test/transform_options_test.rb
+++ b/test/transform_options_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
-class StubTest < MiniTest::Test
+class ExtraOptionsTest < MiniTest::Test
   def setup
     @env = Sprockets::Environment.new(File.join(__dir__, 'fixtures'))
     Sprockets::Commoner::Processor.configure(@env, transform_options: {
-      'vendor-stub/admin' => {
+      'extra-options' => {
         globals: {
           'jquery' => '$'
         }
@@ -13,8 +13,8 @@ class StubTest < MiniTest::Test
     @env.append_path File.join(__dir__, 'fixtures')
   end
 
-  def test_stub
-    assert asset = @env['vendor-stub.js']
+  def test_transform_options
+    assert asset = @env['extra-options.js']
     assert_equal <<-JS.chomp, asset.to_s.chomp
 !function() {
 var __commoner_initialize_module__ = function(f) {
@@ -23,21 +23,11 @@ var __commoner_initialize_module__ = function(f) {
   return module.exports;
 };
 var global = window;
-var __commoner_helper__interopRequireDefault = function (obj) {
-  return obj && obj.__esModule ? obj : {
-    default: obj
-  };
-};
-var __commoner_module__vendor_stub$admin$whatever_js = __commoner_initialize_module__(function (module, exports) {
-  'use strict';
 
-  var _jquery2 = __commoner_helper__interopRequireDefault($);
+var __commoner_module__extra_options$index_js = __commoner_initialize_module__(function (module, exports) {
 
-  (0, _jquery2.default)(function () {
-    return console.log('1337');
-  });
+  $.ajax('/whatever');
 });
-var __commoner_module__vendor_stub$index_js = {};
 }();
 JS
   end


### PR DESCRIPTION
This PR adds an `extra_options` (other name proposals welcome) argument to processor, making it possible to configure any path to use a certain set of commoner options, instead of the brittle and not very useful babelrc way of configuring. This also removes configuring commoner in babelrc (this option was hacky and undocumented).

You can now set the globals map using something like the following:

```
Sprockets::Commoner::Processor.configure(@env, extra_options: {
  'app/assets/javascripts/node_modules' => {
    globals: {
      'jquery' => '$'
    }
  }
})
```

This will now also affect everything inside node_modules.

@lemonmade @GoodForOneFare 