### PR TITLE
Ensure that a coffeescript file contains an identifier if needed

### DIFF
--- a/js/babel-plugin-sprockets-commoner-internal/index.js
+++ b/js/babel-plugin-sprockets-commoner-internal/index.js
@@ -56,7 +56,7 @@ module.exports = function (context) {
    * If we're requiring a CoffeeScript file, we're going to be assuming that we're assigning to the global namespace in that file.
    * so, use a RegExp to find out that variable definition. (yep)
    */
-  function findDeclarationInCoffeeFile(path) {
+  function findDeclarationInCoffeeFile(path, ensureIdentifierIsPresent) {
     var contents = fs.readFileSync(path);
     var identifiers = [];
 
@@ -65,6 +65,9 @@ module.exports = function (context) {
     }
 
     if (identifiers.length === 0) {
+      if (ensureIdentifierIsPresent) {
+        throw new Error('No identifier found in ' + path);
+      }
       return false;
     } else if (identifiers.length > 1) {
       throw new Error('Multiple identifiers found in ' + path);
@@ -136,7 +139,7 @@ module.exports = function (context) {
 
       if (/\.coffee$/.test(resolvedPath)) {
         // If it's a coffee script file, look for global variable assignments.
-        return findDeclarationInCoffeeFile(resolvedPath);
+        return findDeclarationInCoffeeFile(resolvedPath, ensureTargetIsProcessed);
       } else {
         if (ensureTargetIsProcessed) {
           file.metadata.targetsToProcess.push(resolvedPath);

--- a/js/babel-plugin-sprockets-commoner-internal/test/errors/coffee-missing-identifier/actual.js
+++ b/js/babel-plugin-sprockets-commoner-internal/test/errors/coffee-missing-identifier/actual.js
@@ -1,0 +1,1 @@
+var Something = require('./nothing');

--- a/js/babel-plugin-sprockets-commoner-internal/test/errors/coffee-missing-identifier/options.js
+++ b/js/babel-plugin-sprockets-commoner-internal/test/errors/coffee-missing-identifier/options.js
@@ -1,0 +1,8 @@
+var path = require('path');
+
+var rootDir = path.resolve(__dirname, './');
+
+module.exports = {
+  sourceRoot: rootDir,
+  error: __dirname + "/actual.js: No identifier found in " + __dirname + "/nothing.coffee"
+};


### PR DESCRIPTION
This PR makes sure that if a coffeescript file is required and an identifier is used from said file, the file needs to contain an identifier. Previously this could cause misconfigurations to lead to silently replacing the module with an empty namespace.

@lemonmade @GoodForOneFare 