### PR TITLE
Add support for automatic use of expose directives from other files

### DIFF
--- a/js/babel-plugin-sprockets-commoner-internal/path-to-identifier.js
+++ b/js/babel-plugin-sprockets-commoner-internal/path-to-identifier.js
@@ -1,0 +1,11 @@
+// Transform a path into a variable name
+module.exports = function pathToIdentifier(path) {
+  var escapedPath = path.replace(/[^a-zA-Z0-9_]/g, function (match) {
+    if (match === '/') {
+      return '$';
+    } else {
+      return '_';
+    }
+  });
+  return '__commoner_module__' + escapedPath;
+};

--- a/lib/sprockets/commoner.rb
+++ b/lib/sprockets/commoner.rb
@@ -10,6 +10,7 @@ module Sprockets
   register_postprocessor 'application/javascript', ::Sprockets::Commoner::Processor
   register_transformer 'application/json', 'application/javascript', ::Sprockets::Commoner::JSONProcessor
   register_bundle_metadata_reducer 'application/javascript', :commoner_enabled, false, :|
+  register_bundle_metadata_reducer 'application/javascript', :commoner_required, Set.new, :+
   register_bundle_metadata_reducer 'application/javascript', :commoner_used_helpers, Set.new, :+
   register_bundle_processor 'application/javascript', ::Sprockets::Commoner::Bundle
 end

--- a/lib/sprockets/commoner/bundle.rb
+++ b/lib/sprockets/commoner/bundle.rb
@@ -3,20 +3,27 @@ require 'schmooze'
 module Sprockets
   module Commoner
     class Bundle < Schmooze::Base
+
+      InaccessibleStubbedFileError = Class.new(::StandardError)
+
+      JS_PACKAGE_PATH = File.expand_path('../../../js', __dir__)
+
       dependencies generator: 'babel-generator.default',
         babelHelpers: 'babel-helpers',
-        t: 'babel-types'
+        t: 'babel-types',
+        pathToIdentifier: 'babel-plugin-sprockets-commoner-internal/path-to-identifier'
 
-      method :generate_helpers, <<-JS
-function(helpers) {
-  if (helpers.length === 0) {
+      method :generate_header, <<-JS
+function(helpers, globalIdentifiers) {
+  var declarators = helpers.map(function(helper) {
+    return t.variableDeclarator(t.identifier('__commoner_helper__' + helper), babelHelpers.get(helper));
+  }).concat(globalIdentifiers.map(function(item) {
+    return t.variableDeclarator(t.identifier(pathToIdentifier(item[0])), t.identifier(item[1]));
+  }));
+  if (declarators.length === 0) {
     return '';
   }
-  var declaration = t.variableDeclaration('var',
-    helpers.map(function(helper) {
-      return t.variableDeclarator(t.identifier('__commoner_helper__' + helper), babelHelpers.get(helper));
-    })
-  );
+  var declaration = t.variableDeclaration('var', declarators);
   return generator(declaration).code;
 }
 JS
@@ -34,21 +41,40 @@ JS
       OUTRO = <<-JS.freeze
 }();
 JS
+      def initialize(root)
+        super(root, 'NODE_PATH' => JS_PACKAGE_PATH)
+      end
+
       def self.instance(env)
         @instance ||= new(env.root)
       end
 
       def self.call(input)
-        instance(input[:environment]).call(input)
+        env = input[:environment]
+        instance(env).call(input)
       end
 
       def call(input)
         return unless input[:metadata][:commoner_enabled]
+        env = input[:environment]
+        # Get the filenames of all the assets that are included in the bundle
+        assets_in_bundle = Set.new(input[:metadata][:included]) { |uri| env.load(uri).filename }
+        # Subtract the assets in the bundle from those that are required. The missing assets were excluded through stubbing.
+        assets_missing = input[:metadata][:commoner_required] - assets_in_bundle
 
-        used_helpers = input[:metadata][:commoner_used_helpers]
-        helpers = generate_helpers(used_helpers.to_a)
+        global_identifiers = assets_missing.map do |filename|
+          uri, _ = env.resolve(filename, type: input[:content_type], pipeline: :self, compat: false)
+          asset = env.load(uri)
+          # Retrieve the global variable the file is exposed through
+          global = asset.metadata[:commoner_global_identifier]
+          raise InaccessibleStubbedFileError, "#{filename} is stubbed in #{input[:filename]} but doesn't define a global. Add an 'expose' directive." if global.nil?
+          [filename.slice(env.root.size + 1, filename.size), global]
+        end
+
+        used_helpers = input[:metadata][:commoner_used_helpers].to_a
+        header_code = generate_header(used_helpers, global_identifiers)
         {
-          data: "#{PRELUDE}#{helpers}\n#{input[:data]}#{OUTRO}"
+          data: "#{PRELUDE}#{header_code}\n#{input[:data]}#{OUTRO}"
         }
       end
     end

--- a/test/fixtures/vendor-stub/admin/whatever.js
+++ b/test/fixtures/vendor-stub/admin/whatever.js
@@ -1,3 +1,4 @@
 import $ from 'jquery';
+import number from '../stubme';
 
-$(() => console.log('1337'));
+$(() => console.log('1337', number));

--- a/test/fixtures/vendor-stub/stubme.js
+++ b/test/fixtures/vendor-stub/stubme.js
@@ -1,0 +1,5 @@
+'expose window.Important';
+
+window.$ = window.jQuery = require('jquery');
+
+export default 1;

--- a/test/fixtures/vendor-stub/vendors.js
+++ b/test/fixtures/vendor-stub/vendors.js
@@ -1,1 +1,1 @@
-//= require ./node_modules/jquery/dist/jquery
+//= require ./stubme

--- a/test/stub_test.rb
+++ b/test/stub_test.rb
@@ -27,14 +27,17 @@ var __commoner_helper__interopRequireDefault = function (obj) {
   return obj && obj.__esModule ? obj : {
     default: obj
   };
-};
+},
+    __commoner_module__vendor_stub$stubme_js = window.Important;
 var __commoner_module__vendor_stub$admin$whatever_js = __commoner_initialize_module__(function (module, exports) {
   'use strict';
 
   var _jquery2 = __commoner_helper__interopRequireDefault($);
 
+  var _stubme2 = __commoner_helper__interopRequireDefault(__commoner_module__vendor_stub$stubme_js);
+
   (0, _jquery2.default)(function () {
-    return console.log('1337');
+    return console.log('1337', _stubme2.default);
   });
 });
 var __commoner_module__vendor_stub$index_js = {};


### PR DESCRIPTION
@lemonmade @rafaelfranca @GoodForOneFare 

This PR instruments the commoner bundler to retrieve the global identifiers of any files that are required, but not included in the bundle (that is, they were stubbed). It then uses these global identifiers to fulfill the references.