### PR TITLE
Make the Sprockets asset depend on environment variables used

### DIFF
--- a/js/babel-plugin-sprockets-commoner-internal/index.js
+++ b/js/babel-plugin-sprockets-commoner-internal/index.js
@@ -203,13 +203,17 @@ module.exports = function (context) {
       if (file.metadata.targetsToProcess == null) {
         file.metadata.targetsToProcess = [];
       }
+      if (file.metadata.includedEnvironmentVariables == null) {
+        file.metadata.includedEnvironmentVariables = [];
+      }
     },
 
     visitor: {
-      MemberExpression: function MemberExpression(path) {
+      MemberExpression: function MemberExpression(path, state) {
         if (path.get("object").matchesPattern("process.env")) {
           var key = path.toComputedKey();
           if (t.isStringLiteral(key)) {
+            state.file.metadata.includedEnvironmentVariables.push(key.value);
             path.replaceWith(t.valueToNode(process.env[key.value]));
           }
         }

--- a/js/babel-plugin-sprockets-commoner-internal/test/fixtures/inline-env/options.js
+++ b/js/babel-plugin-sprockets-commoner-internal/test/fixtures/inline-env/options.js
@@ -4,4 +4,5 @@ var rootDir = path.resolve(__dirname, '../../../');
 
 module.exports = {
   sourceRoot: rootDir,
+  expectedIncludedEnvironmentVariables: ['NODE_ENV'],
 };

--- a/js/babel-plugin-sprockets-commoner-internal/test/index.js
+++ b/js/babel-plugin-sprockets-commoner-internal/test/index.js
@@ -46,6 +46,9 @@ describe('babel-plugin-sprockets-commoner-internal', function() {
       if (options.expectedTargetsToProcess != null) {
         assert.deepEqual(options.expectedTargetsToProcess, result.metadata.targetsToProcess);
       }
+      if (options.expectedIncludedEnvironmentVariables) {
+        assert.deepEqual(options.expectedIncludedEnvironmentVariables, result.metadata.includedEnvironmentVariables);
+      }
     });
   });
 

--- a/lib/sprockets/commoner.rb
+++ b/lib/sprockets/commoner.rb
@@ -13,6 +13,10 @@ module Sprockets
   register_bundle_metadata_reducer 'application/javascript', :commoner_required, Set.new, :+
   register_bundle_metadata_reducer 'application/javascript', :commoner_used_helpers, Set.new, :+
   register_bundle_processor 'application/javascript', ::Sprockets::Commoner::Bundle
+  register_dependency_resolver 'commoner-environment-variable' do |env, str|
+    _, variable = str.split(':', 2)
+    ENV[variable]
+  end
 end
 
 require 'sprockets/commoner/railtie' if defined?(Rails)

--- a/lib/sprockets/commoner/processor.rb
+++ b/lib/sprockets/commoner/processor.rb
@@ -7,7 +7,7 @@ module Sprockets
 
       ExcludedFileError = Class.new(::StandardError)
 
-      VERSION = '2'.freeze
+      VERSION = '3'.freeze
       BABELRC_FILE = '.babelrc'.freeze
       PACKAGE_JSON = 'package.json'.freeze
       JS_PACKAGE_PATH = File.expand_path('../../../js', __dir__)
@@ -98,6 +98,10 @@ module Sprockets
         result['metadata']['required'].each do |r|
           asset = resolve(r, accept: input[:content_type], pipeline: :self)
           @required.insert(insertion_index, asset)
+        end
+
+        result['metadata']['includedEnvironmentVariables'].each do |env|
+          @dependencies << "commoner-environment-variable:#{env}"
         end
 
         {

--- a/test/cache_key_test.rb
+++ b/test/cache_key_test.rb
@@ -7,7 +7,7 @@ class CacheKeyTest < MiniTest::Test
 
   def test_default_cache_key
     processor = Sprockets::Commoner::Processor.new(@dir)
-    assert_equal ['Sprockets::Commoner::Processor', '2', '6.9.1', [@dir], [File.join(@dir, 'vendor/bundle')], [/node_modules/.to_s], []], processor.cache_key
+    assert_equal ['Sprockets::Commoner::Processor', '3', '6.9.1', [@dir], [File.join(@dir, 'vendor/bundle')], [/node_modules/.to_s], []], processor.cache_key
   end
 
   def test_opts_cache_key
@@ -18,7 +18,7 @@ class CacheKeyTest < MiniTest::Test
         }
       }
     })
-    assert_equal ['Sprockets::Commoner::Processor', '2', '6.9.1', [@dir], [File.join(@dir, 'vendor/bundle')], [/node_modules/.to_s], [[/index.js$/.to_s, {globals: {'jquery' => '$'}}]]], processor.cache_key
+    assert_equal ['Sprockets::Commoner::Processor', '3', '6.9.1', [@dir], [File.join(@dir, 'vendor/bundle')], [/node_modules/.to_s], [[/index.js$/.to_s, {globals: {'jquery' => '$'}}]]], processor.cache_key
   end
 
   def test_babel_missing_cache_key

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class EnvTest < MiniTest::Test
+  def setup
+    ENV['SOME_RANDOM_ENVIRONMENT_VARIABLE'] = 'yes_indeed'
+
+    @env = Sprockets::Environment.new(File.join(__dir__, 'fixtures'))
+    @env.append_path File.join(__dir__, 'fixtures')
+  end
+
+  def test_dependency
+    assert asset = @env['process-env.js']
+    assert_includes asset.metadata[:dependencies], 'commoner-environment-variable:NODE_ENV'
+  end
+
+  def test_dependency_value
+    assert_equal @env.resolve_dependency('commoner-environment-variable:SOME_RANDOM_ENVIRONMENT_VARIABLE'), 'yes_indeed'
+  end
+end

--- a/test/fixtures/process-env/index.js
+++ b/test/fixtures/process-env/index.js
@@ -1,0 +1,3 @@
+if (process.env.NODE_ENV !== "production") {
+  console.log('blabla debug debug');
+}


### PR DESCRIPTION
This PR adds any included environment variables to the Sprockets asset dependencies, so that changes in said environment variables cause the cache to be invalidated and the asset to be reprocessed. This is important because many projects (like React) used `NODE_ENV` to conditionally exclude code that doesn't need to be in the production build. I already added support for substituting the variables in a previous PR but didn't add the cache dependency at the time

for review @rafaelfranca 