### PR TITLE
Make Sprockets 4 compatible

### DIFF
--- a/lib/sprockets/commoner/bundle.rb
+++ b/lib/sprockets/commoner/bundle.rb
@@ -63,7 +63,11 @@ JS
         assets_missing = input[:metadata][:commoner_required] - assets_in_bundle
 
         global_identifiers = assets_missing.map do |filename|
-          uri, _ = env.resolve(filename, type: input[:content_type], pipeline: :self, compat: false)
+          uri, _ = if Sprockets::VERSION < '4'
+            env.resolve(filename, accept: input[:content_type], pipeline: :self, compat: false)
+          else
+            env.resolve(filename, accept: input[:content_type], pipeline: :self)
+          end
           asset = env.load(uri)
           # Retrieve the global variable the file is exposed through
           global = asset.metadata[:commoner_global_identifier]

--- a/sprockets-commoner.gemspec
+++ b/sprockets-commoner.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_dependency "sprockets", ">= 3", "< 4"
+  spec.add_dependency "sprockets", ">= 3", "< 5"
   spec.add_dependency "schmooze", "~> 0.1.6"
 
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This makes the tests pass in Sprockets 4. I still need to add source map support but I'll do that in a separate PR.

@rafaelfranca @TylerHorth 