### PR TITLE
Remove protection against defining a variable that's a package identifier

### DIFF
--- a/js/babel-plugin-sprockets-commoner-internal/index.js
+++ b/js/babel-plugin-sprockets-commoner-internal/index.js
@@ -158,12 +158,8 @@ module.exports = function (context) {
       if (name === false) {
         path.get('init').replaceWith(t.objectExpression([]));
       } else {
-        if (path.scope.hasBinding(name)) {
-          path.scope.rename(name);
-        }
         path.scope.rename(path.node.id.name, name);
         path.remove();
-        path.scope.removeBinding(name);
       }
     },
     CallExpression: function CallExpression(path, state) {

--- a/js/babel-plugin-sprockets-commoner-internal/test/fixtures/optional-require/actual.js
+++ b/js/babel-plugin-sprockets-commoner-internal/test/fixtures/optional-require/actual.js
@@ -1,0 +1,8 @@
+try {
+  var exists = require('./doesnt-exist.js');
+  console.log(exists);
+} catch (err) {
+  var exists = require('./exists.js');
+  console.log(exists);
+}
+console.log(exists);

--- a/js/babel-plugin-sprockets-commoner-internal/test/fixtures/optional-require/expected.js
+++ b/js/babel-plugin-sprockets-commoner-internal/test/fixtures/optional-require/expected.js
@@ -1,0 +1,10 @@
+var __commoner_module__actual_js = __commoner_initialize_module__(function (module, exports) {
+  'use strict';
+
+  try {
+    console.log(__commoner_module__exists_js);
+  } catch (err) {
+    console.log(__commoner_module__exists_js);
+  }
+  console.log(__commoner_module__exists_js);
+});

--- a/js/babel-plugin-sprockets-commoner-internal/test/fixtures/optional-require/options.js
+++ b/js/babel-plugin-sprockets-commoner-internal/test/fixtures/optional-require/options.js
@@ -1,0 +1,3 @@
+module.exports = {
+  sourceRoot: __dirname
+}

--- a/js/babel-plugin-sprockets-commoner-internal/test/fixtures/optional-require/package.json
+++ b/js/babel-plugin-sprockets-commoner-internal/test/fixtures/optional-require/package.json
@@ -1,0 +1,5 @@
+{
+  "browser": {
+    "./doesnt-exist.js": "./exists.js"
+  }
+}


### PR DESCRIPTION
It caused issues when the same variable was using for requires multiple times, which caused the binding to be removed by one of the requires. There was protection against someone defining a variable that was a commoner package identifier, but that isn't really needed.

@tessalt 

Fixes #40 