### PR TITLE
Support ExecJS globals

### DIFF
--- a/lib/sprockets/commoner/bundle.rb
+++ b/lib/sprockets/commoner/bundle.rb
@@ -35,7 +35,7 @@ var __commoner_initialize_module__ = function(f) {
   f.call(module.exports, module, module.exports);
   return module.exports;
 };
-var global = window;
+  var global = global || window || self
 JS
 
       OUTRO = <<-JS.freeze

--- a/lib/sprockets/commoner/bundle.rb
+++ b/lib/sprockets/commoner/bundle.rb
@@ -35,7 +35,14 @@ var __commoner_initialize_module__ = function(f) {
   f.call(module.exports, module, module.exports);
   return module.exports;
 };
-  var global = global || window || self
+
+if (typeof window !== 'undefined') {
+  global = window;
+} else if (typeof global !== 'undefined') {
+  global = global;
+} else {
+  global = this;
+}
 JS
 
       OUTRO = <<-JS.freeze

--- a/lib/sprockets/commoner/version.rb
+++ b/lib/sprockets/commoner/version.rb
@@ -1,5 +1,5 @@
 module Sprockets
   module Commoner
-    VERSION = '0.6.3'
+    VERSION = '0.6.3pr0'
   end
 end


### PR DESCRIPTION
`window` is not allowed in ExecJS, so what I'm trying to do is alias `window` only if it exists, otherwise, alias `this` which I think in ExecJS refers to the global names, I'm opening the request to discuss this, but I understand the solution is clunky. This addresses #61